### PR TITLE
Adding test for Basic Chat Testing 

### DIFF
--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -32,3 +32,8 @@ from typing import Dict, List, Union, Callable, TYPE_CHECKING
 from pieces_os_client import Conversation, StreamedIdentifiers, Asset
 from abc import ABC, abstractmethod
 import threading
+from pieces_copilot_sdk.copilot import Copilot
+from pieces_copilot_sdk.basic_identifier.asset import BasicAsset
+from pieces_copilot_sdk.streamed_identifiers.assets_snapshot import AssetSnapshot
+from websockets import *
+from pieces_copilot_sdk.client import PiecesClient

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch, call
-from typing import Literal, Optional, List, TYPE_CHECKING
-from abc import ABC, abstractmethod
+from typing import Literal, Optional,TYPE_CHECKING , Dict, List, Union, Callable
 from pieces_os_client import (
     ApiClient,
     Application,
@@ -28,7 +27,7 @@ import atexit
 import sys
 import importlib.util
 import queue
-from typing import Dict, List, Union, Callable, TYPE_CHECKING
+from typing import 
 from pieces_os_client import Conversation, StreamedIdentifiers, Asset
 from abc import ABC, abstractmethod
 import threading

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -55,3 +55,7 @@ class TestBasicChat:
         chat = BasicChat("test_id")
         assert chat.id == "test_id"
         assert chat.name == "Test Conversation"
+
+    def test_init_invalid_id(self):
+        with pytest.raises(ValueError, match="Conversation not found"):
+            BasicChat("invalid_id")

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -50,3 +50,8 @@ class TestBasicChat:
         self.mock_conversation.name = "Test Conversation"
         ConversationsSnapshot.identifiers_snapshot = {"test_id": self.mock_conversation}
         ConversationsSnapshot.pieces_client = Mock()
+
+    def test_init_valid_id(self):
+        chat = BasicChat("test_id")
+        assert chat.id == "test_id"
+        assert chat.name == "Test Conversation"

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -37,3 +37,7 @@ from pieces_copilot_sdk.basic_identifier.asset import BasicAsset
 from pieces_copilot_sdk.streamed_identifiers.assets_snapshot import AssetSnapshot
 from websockets import *
 from pieces_copilot_sdk.client import PiecesClient
+from pieces_copilot_sdk.basic_identifier.basic import Basic
+from pieces_copilot_sdk.basic_identifier.message import BasicMessage
+from pieces_copilot_sdk.basic_identifier.chat import BasicChat
+

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -117,3 +117,9 @@ class TestBasicChat:
         
         chat = BasicChat("test_id")
         assert chat.annotations is None
+
+    def test_delete(self):
+        chat = BasicChat("test_id")
+        chat.delete()
+        
+        ConversationsSnapshot.pieces_client.conversations_api.conversations_delete_specific_conversation.assert_called_once_with("test_id")

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -123,3 +123,10 @@ class TestBasicChat:
         chat.delete()
         
         ConversationsSnapshot.pieces_client.conversations_api.conversations_delete_specific_conversation.assert_called_once_with("test_id")
+
+    @patch.object(ConversationsSnapshot, 'pieces_client')
+    def test_edit_conversation(self, mock_pieces_client):
+        mock_conversation = Mock()
+        BasicChat._edit_conversation(mock_conversation)
+        
+        mock_pieces_client.conversation_api.conversation_update.assert_called_once_with(False, mock_conversation)

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import Mock, patch, call
+from typing import Literal, Optional, List, TYPE_CHECKING
+from abc import ABC, abstractmethod
+from pieces_os_client import (
+    ApiClient,
+    Application,
+    Configuration,
+    ConversationApi,
+    ConversationMessageApi,
+    ConversationMessagesApi,
+    ConversationsApi,
+    QGPTApi,
+    UserApi,
+    FormatApi,
+    ConnectorApi,
+    SeededConnectorConnection,
+    SeededTrackedApplication,
+    AssetApi,
+    AssetsApi,
+    FragmentMetadata,
+    ModelsApi,
+    AnnotationApi
+)
+from typing import Optional,Dict
+import platform
+import atexit
+import sys
+import importlib.util
+import queue
+from typing import Dict, List, Union, Callable, TYPE_CHECKING
+from pieces_os_client import Conversation, StreamedIdentifiers, Asset
+from abc import ABC, abstractmethod
+import threading

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -43,3 +43,10 @@ from pieces_copilot_sdk.basic_identifier.chat import BasicChat
 from pieces_copilot_sdk.streamed_identifiers._streamed_identifiers import StreamedIdentifiersCache
 from pieces_copilot_sdk.streamed_identifiers.conversations_snapshot import ConversationsSnapshot
 
+class TestBasicChat:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.mock_conversation = Mock(id="test_id", messages=Mock(indices={}), annotations=None)
+        self.mock_conversation.name = "Test Conversation"
+        ConversationsSnapshot.identifiers_snapshot = {"test_id": self.mock_conversation}
+        ConversationsSnapshot.pieces_client = Mock()

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -40,4 +40,6 @@ from pieces_copilot_sdk.client import PiecesClient
 from pieces_copilot_sdk.basic_identifier.basic import Basic
 from pieces_copilot_sdk.basic_identifier.message import BasicMessage
 from pieces_copilot_sdk.basic_identifier.chat import BasicChat
+from pieces_copilot_sdk.streamed_identifiers._streamed_identifiers import StreamedIdentifiersCache
+from pieces_copilot_sdk.streamed_identifiers.conversations_snapshot import ConversationsSnapshot
 

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -59,3 +59,11 @@ class TestBasicChat:
     def test_init_invalid_id(self):
         with pytest.raises(ValueError, match="Conversation not found"):
             BasicChat("invalid_id")
+
+    def test_name_property(self):
+        chat = BasicChat("test_id")
+        assert chat.name == "Test Conversation"
+
+        chat.name = "New Name"
+        assert chat.name == "New Name"
+        ConversationsSnapshot.pieces_client.conversation_api.conversation_update.assert_called_once()

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -111,3 +111,9 @@ class TestBasicChat:
         
         chat = BasicChat("test_id")
         assert chat.annotations == ["annotation1", "annotation2"]
+
+    def test_annotations_property_none(self):
+        ConversationsSnapshot.identifiers_snapshot["test_id"].annotations = None
+        
+        chat = BasicChat("test_id")
+        assert chat.annotations is None

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -67,3 +67,8 @@ class TestBasicChat:
         chat.name = "New Name"
         assert chat.name == "New Name"
         ConversationsSnapshot.pieces_client.conversation_api.conversation_update.assert_called_once()
+
+    def test_name_property_default(self):
+        self.mock_conversation.name = None
+        chat = BasicChat("test_id")
+        assert chat.name == "New Conversation"

--- a/tests/test_basic_chat.py
+++ b/tests/test_basic_chat.py
@@ -104,3 +104,10 @@ class TestBasicChat:
         for call_args in mock_basic_message_init.call_args_list:
             assert isinstance(call_args[0][0], Mock)
             assert call_args[0][0].id in ["msg1", "msg2"]
+
+    def test_annotations_property(self):
+        mock_annotations = Mock(iterable=["annotation1", "annotation2"])
+        ConversationsSnapshot.identifiers_snapshot["test_id"].annotations = mock_annotations
+        
+        chat = BasicChat("test_id")
+        assert chat.annotations == ["annotation1", "annotation2"]


### PR DESCRIPTION
## Description
This PR introduces a comprehensive test suite for the BasicChat class, covering various aspects of its functionality including initialization, property access, message handling, and API interactions.

## Changes
- Add TestBasicChat class with setup fixture
- Implement tests for BasicChat initialization with valid and invalid IDs
- Add tests for name property, including default value handling
- Implement test for messages method, covering message retrieval and deletion scenarios
- Add tests for annotations property, including cases where annotations are present and absent
- Implement test for delete method
- Add test for _edit_conversation static method

## Test Coverage
The new test suite includes the following tests:

1. `test_init_valid_id`:
   - Verifies that BasicChat initializes correctly with a valid conversation ID
   - Checks that the ID and name are set correctly

2. `test_init_invalid_id`:
   - Ensures that BasicChat raises a ValueError when initialized with an invalid conversation ID

3. `test_name_property`:
   - Checks that the name property can be read correctly
   - Verifies that the name can be updated
   - Ensures that updating the name triggers an API call

4. `test_name_property_default`:
   - Verifies that the name property defaults to "New Conversation" when the conversation name is not set

5. `test_messages`:
   - Checks that the messages method returns the correct number of messages
   - Ensures that deleted messages are not included in the returned list
   - Verifies that returned messages are instances of BasicMessage
   - Checks that the _get_message method is called with correct message IDs

6. `test_annotations_property`:
   - Verifies that the annotations property correctly returns the list of annotations when present

7. `test_annotations_property_none`:
   - Ensures that the annotations property returns None when no annotations are present

8. `test_delete`:
   - Checks that the delete method calls the appropriate API method to delete the conversation

9. `test_edit_conversation`:
   - Verifies that the _edit_conversation static method correctly calls the API to update the conversation

Each test is designed to cover a specific aspect of the BasicChat class functionality, ensuring comprehensive coverage of the class's behavior.

## Test Results
<img width="912" alt="Screenshot 2024-08-20 at 3 37 37 AM" src="https://github.com/user-attachments/assets/b352b31b-7c69-4b40-a66f-7251666941c3">

